### PR TITLE
Update CI to use Xcode 26

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   test:
     name: Run Tests
-    runs-on: macos-15
+    runs-on: macos-26
 
     steps:
     - name: Checkout code

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Select Xcode version
-      run: sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
+      run: sudo xcode-select -s /Applications/Xcode_26.app/Contents/Developer
 
     - name: Show Swift version
       run: swift --version

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ A Swift package for text-to-speech audio generation with support for multiple TT
 - Swift 6.0+
 - SwiftData
 
+## Development Environment
+
+Continuous integration builds target macOS 26 runners using Xcode 26 to ensure compatibility with the latest Apple tooling.
+
 ## Installation
 
 ### Swift Package Manager


### PR DESCRIPTION
## Summary
- update the CI workflow to select Xcode 26 when running tests

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e5a3eec5748321b054a8df456d4046