### PR TITLE
Add AI-focused usage and API reference docs

### DIFF
--- a/AI_REFERENCE.md
+++ b/AI_REFERENCE.md
@@ -1,0 +1,48 @@
+# SwiftHablaré AI Reference Sheet
+
+This sheet is optimized for bots needing rapid recall of project fundamentals.
+
+## Core Facts
+
+- **Purpose**: Unified text-to-speech abstraction over Apple TTS and ElevenLabs.
+- **Language/Runtime**: Swift 6 targeting iOS 17+/macOS 14+ with SwiftData persistence.
+- **Entry Point**: `VoiceProviderManager` orchestrates providers and caching.
+- **State Storage**: SwiftData (`AudioFile`, `VoiceModel`) + Keychain for secrets.
+- **UI Helpers**: SwiftUI widgets in `Sources/SwiftHablare/UI/` wrap provider selection and configuration.
+
+## Default Providers
+
+| Provider | ID | Requires Key | Notes |
+| --- | --- | --- | --- |
+| ElevenLabs | `elevenlabs` | ✅ | Network-backed voices, needs API key saved as `elevenlabs-api-key`. |
+| Apple TTS | `apple` | ❌ | Local system voices, generates silent placeholder audio in current build. |
+
+## Memory-Saving Tips for Agents
+
+1. **Cache Awareness**: `generateAndCacheAudio` reuses existing audio automatically—avoid duplicate generation loops.
+2. **Provider Selection**: Check `manager.currentProviderType` before switching; persisted via `UserDefaults`.
+3. **Credential Checks**: Prefer `KeychainManager.shared.hasAPIKey` before attempting ElevenLabs calls.
+4. **Voice Lists**: Use `getVoices(forceRefresh: false)` whenever possible; SwiftData caches results by provider.
+5. **Error Surfacing**: Inspect `manager.lastError` after failures for user-facing diagnostics.
+
+## Typical Automation Sequence
+
+```
+ensureAPIKey()
+let voices = try await manager.getVoices()
+let audio = try await manager.generateAndCacheAudio(...)
+try manager.writeAudioFile(audio, to: outputURL)
+```
+
+Wrap task-specific logic around this pipeline.
+
+## Testing Hooks
+
+- Unit tests live under `Tests/SwiftHablareTests/` and focus on SwiftUI view behavior with injected managers.
+- No CLI entry point exists; interactions happen through Swift APIs.
+
+## Extensibility Reminders
+
+- New providers must conform to `VoiceProvider` and be registered with the manager.
+- Persist provider-specific metadata by extending SwiftData models or adding new ones to the host app's `ModelContainer`.
+- Update documentation (`API.md`, `USAGE.md`) when exposing additional public types or workflows.

--- a/API.md
+++ b/API.md
@@ -1,0 +1,95 @@
+# SwiftHablaré API Reference (Concise)
+
+This document highlights the primary types exposed by SwiftHablaré so that automated agents can understand the surface area without scanning the full source tree.
+
+## Module Layout
+
+```
+Sources/SwiftHablare/
+├── KeychainManager.swift        // Secure credential storage helper
+├── SwiftHablare.swift           // Package entry point exports
+├── VoiceProvider.swift          // Provider protocol + enums
+├── VoiceProviderManager.swift   // High-level orchestration
+├── Models/                      // SwiftData models + DTOs
+└── Providers/                   // Provider-specific implementations
+```
+
+SwiftUI helper views live in `Sources/SwiftHablare/UI/`.
+
+## Core Types
+
+### `VoiceProviderManager`
+High-level coordinator responsible for:
+- Registering providers (`registerProvider(_:)`).
+- Persisting the selected provider (`currentProviderType`).
+- Fetching voices with automatic SwiftData caching (`getVoices(forceRefresh:)`).
+- Generating audio, with (`generateAndCacheAudio`) or without (`generateAudio`) persistence.
+- Writing cached audio to disk (`writeAudioFile(_:to:)`).
+- Switching providers and emitting errors through `lastError`.
+
+A `ModelContext` is required at initialization; caching relies on `AudioFile` and `VoiceModel` entities.
+
+### `VoiceProvider` Protocol
+Providers must supply:
+- Identity metadata (`providerId`, `displayName`, `requiresAPIKey`).
+- Runtime state (`isConfigured()`).
+- Voice discovery (`fetchVoices()`).
+- Audio generation (`generateAudio(text:voiceId:)`).
+- Duration estimation (`estimateDuration(text:voiceId:)`).
+- Voice availability checks (`isVoiceAvailable(voiceId:)`).
+
+`VoiceProviderType` offers canonical IDs (`.elevenlabs`, `.apple`) and human-readable labels. Errors are represented by `VoiceProviderError` (`.notConfigured`, `.networkError`, `.invalidResponse`, `.unsupportedProvider`, `.notSupported`).
+
+### Data Models
+- `Voice`: Codable DTO used across providers.
+- `AudioFile`: SwiftData model caching generated audio bytes plus metadata (format, duration, sample rate, etc.).
+- `VoiceModel`: SwiftData cache for provider voice listings.
+
+Conversions between `Voice` and `VoiceModel` are implemented as helpers on `VoiceModel`.
+
+## Providers
+
+### `ElevenLabsVoiceProvider`
+- Requires API key stored under `"elevenlabs-api-key"` in `KeychainManager`.
+- Fetches localized voice lists from `https://api.elevenlabs.io/v1/voices` filtered by the current locale.
+- Generates audio via `https://api.elevenlabs.io/v1/text-to-speech/{voiceId}` with configurable body payload.
+- Estimates duration heuristically by character count and adds a 15% buffer.
+- Validates voice availability via `GET /v1/voices/{voiceId}`.
+- Includes Codable structs (`VoicesResponse`, `ElevenLabsVoice`) to decode API payloads and expose helper properties (`language`, `locality`, `gender`).
+
+### `AppleVoiceProvider`
+- Always configured (`requiresAPIKey == false`).
+- Uses `AVSpeechSynthesisVoice` to gather voices, filtering by the system language and enriching metadata (quality, gender guess).
+- Generates placeholder audio using `AVAudioFile` + `AVAudioPCMBuffer` to avoid crashes from `AVSpeechSynthesizer.write` (silent CAF output).
+- Estimates duration using `AVSpeechUtterance` heuristics with a small safety buffer.
+- Checks availability through `AVSpeechSynthesisVoice(identifier:)` or scanning the voice list.
+
+## Utilities
+
+### `KeychainManager`
+Singleton (`shared`) wrapping Keychain CRUD:
+- `saveAPIKey(_:for:)`
+- `getAPIKey(for:)`
+- `deleteAPIKey(for:)`
+- `hasAPIKey(for:)`
+- `getObfuscatedAPIKey(for:)`
+
+Throws `KeychainError` variants (`.invalidData`, `.notFound`, `.unableToSave`, `.unableToDelete`).
+
+## SwiftUI Components
+
+- `VoiceProviderWidget`: Provider selector + status UI.
+- `VoiceSettingsWidget`: Aggregates provider controls, API key management, and voice picker.
+- `VoicePickerWidget`: Voice search, filter, and preview list. Exposes reusable row view (`VoiceRow`) and binding-based variant (`VoicePickerWithBinding`).
+
+Each widget expects a `VoiceProviderManager` environment object and uses the SwiftData models for persistence.
+
+## Extension Points
+
+To add a new provider:
+1. Implement `VoiceProvider` with the provider ID and required network logic.
+2. Register the provider in `VoiceProviderManager` (either via constructor or `registerProvider`).
+3. Optionally add SwiftUI controls mirroring the patterns in the existing widgets.
+4. Persist provider-specific metadata by extending `VoiceModel`/`AudioFile` or introducing new SwiftData models.
+
+When altering persistence, update migrations or `ModelContainer` setup inside host apps to include the new models.

--- a/USAGE.md
+++ b/USAGE.md
@@ -1,0 +1,115 @@
+# SwiftHablaré Usage Guide
+
+This guide summarizes the day-to-day tasks most automations perform when integrating or extending SwiftHablaré. It condenses the key workflows so AI agents can operate with minimal context switching.
+
+## 1. Package Integration Checklist
+
+1. Add the package to the `dependencies` array in your `Package.swift`:
+   ```swift
+   .package(url: "https://github.com/stovak/SwiftHablare", from: "1.0.0")
+   ```
+2. Add `SwiftHablare` to the target dependencies that need text-to-speech features.
+3. Ensure the host app targets macOS 14/iOS 17 or newer and uses Swift 6.0 or newer.
+4. Link SwiftData in the host target (SwiftHablaré persists data through it).
+5. On iOS/macOS, entitle the app for microphone/speaker usage when playing audio.
+
+## 2. Bootstrapping the Manager
+
+```swift
+import SwiftData
+import SwiftHablare
+
+let container = try ModelContainer(for: AudioFile.self, VoiceModel.self)
+let manager = VoiceProviderManager(modelContext: container.mainContext)
+```
+
+The manager auto-registers the built-in providers (`ElevenLabsVoiceProvider` and `AppleVoiceProvider`) and restores the last-selected provider from `UserDefaults`.
+
+### Switching Providers
+
+```swift
+manager.switchProvider(to: .apple)
+manager.switchProvider(to: .elevenlabs)
+```
+
+The helper `isCurrentProviderConfigured()` returns `true` when prerequisites (for example, an API key) are satisfied.
+
+## 3. Managing Voices
+
+```swift
+let cachedVoices = try await manager.getVoices()
+let freshVoices = try await manager.getVoices(forceRefresh: true)
+```
+
+Voice metadata is cached in SwiftData (`VoiceModel`). Refresh only when provider-side changes are expected.
+
+To inspect or work with a provider directly:
+
+```swift
+if let provider = manager.getProvider(for: "elevenlabs"), await provider.isVoiceAvailable(voiceId: "voice-id") {
+    let voices = try await provider.fetchVoices()
+}
+```
+
+## 4. Generating Audio
+
+### Cached Generation
+
+```swift
+let audio = try await manager.generateAndCacheAudio(
+    text: "Hello World",
+    voiceId: "voice-id",
+    providerId: "elevenlabs",
+    audioFormat: "mp3"
+)
+```
+
+This method reuses cached audio if the same `(text, voiceId, providerId)` triple already exists, otherwise it stores the new result in SwiftData (`AudioFile`).
+
+### Direct Generation
+
+```swift
+let rawData = try await manager.generateAudio(text: "Hello", voiceId: "voice-id")
+```
+
+Use this when you do not need persistence.
+
+### Persisting to Disk
+
+```swift
+let outputURL = URL(fileURLWithPath: "/tmp/output.mp3")
+try manager.writeAudioFile(audio, to: outputURL)
+```
+
+## 5. API Key Management
+
+`KeychainManager.shared` stores sensitive provider credentials. Typical usage:
+
+```swift
+try KeychainManager.shared.saveAPIKey("your-api-key", for: "elevenlabs-api-key")
+let key = try KeychainManager.shared.getAPIKey(for: "elevenlabs-api-key")
+let isConfigured = KeychainManager.shared.hasAPIKey(for: "elevenlabs-api-key")
+try KeychainManager.shared.deleteAPIKey(for: "elevenlabs-api-key")
+```
+
+## 6. SwiftUI Widgets Snapshot
+
+SwiftHablaré ships SwiftUI helper views designed for macOS/iOS apps. They bind directly to `VoiceProviderManager` and the SwiftData models:
+
+- `VoiceProviderWidget` – Picker for switching providers and showing provider status.
+- `VoiceSettingsWidget` – Composite control for configuring providers and selecting voices.
+- `VoicePickerWidget` – Standalone voice picker that supports searching, filtering, and previews.
+
+Inspect the files under `Sources/SwiftHablare/UI/` for customizable sections. Automated agents can reuse these components in host apps without re-implementing the UI logic.
+
+## 7. Common Automation Tasks
+
+| Task | Call Sequence |
+| --- | --- |
+| Ensure provider credentials exist | `KeychainManager.shared.hasAPIKey` → `saveAPIKey` if missing |
+| Refresh cached voice list | `await manager.getVoices(forceRefresh: true)` |
+| Generate & persist audio | `await manager.generateAndCacheAudio` → `writeAudioFile` |
+| Switch default provider | `manager.switchProvider(to:)` |
+| Enumerate providers | `manager.getAvailableProviders()` |
+
+Refer to [`API.md`](API.md) for type-level details when implementing new providers or extending the data models.


### PR DESCRIPTION
## Summary
- add USAGE.md with step-by-step workflows for integrating SwiftHablaré
- document the public API surface and extension points in API.md
- provide an AI-focused reference sheet with quick facts and automation tips

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5a47593408321b58de98b81c85aa3