### PR TITLE
Align macOS tooling with SwiftFountain

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Select Xcode version
-      run: sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
+      run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
 
     - name: Show Swift version
       run: swift --version

--- a/AI_REFERENCE.md
+++ b/AI_REFERENCE.md
@@ -5,7 +5,8 @@ This sheet is optimized for bots needing rapid recall of project fundamentals.
 ## Core Facts
 
 - **Purpose**: Unified text-to-speech abstraction over Apple TTS and ElevenLabs.
-- **Language/Runtime**: Swift 6 targeting iOS 17+/macOS 14+ with SwiftData persistence.
+- **Language/Runtime**: Swift 6 targeting iOS 17+/macOS 15+ with SwiftData persistence.
+- **Toolchain**: Xcode 16.4 on macOS 15 in CI and development flows.
 - **Entry Point**: `VoiceProviderManager` orchestrates providers and caching.
 - **State Storage**: SwiftData (`AudioFile`, `VoiceModel`) + Keychain for secrets.
 - **UI Helpers**: SwiftUI widgets in `Sources/SwiftHablare/UI/` wrap provider selection and configuration.

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "SwiftHablare",
     platforms: [
-        .macOS(.v14),
+        .macOS(.v15),
         .iOS(.v17)
     ],
     products: [

--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ A Swift package for text-to-speech audio generation with support for multiple TT
 
 ## Requirements
 
-- macOS 14.0+ / iOS 17.0+
+- macOS 15.0+ / iOS 17.0+
 - Swift 6.0+
+- Xcode 16.4+
 - SwiftData
 
 ## Installation
@@ -181,7 +182,7 @@ public final class VoiceModel {
 
 - **Provider ID**: `apple`
 - **Requires API Key**: No
-- **Platform**: macOS, iOS
+- **Platform**: macOS 15+ / iOS 17+
 - **Features**: Built-in system voices, no API key required
 
 ### ElevenLabs Voice Provider

--- a/USAGE.md
+++ b/USAGE.md
@@ -9,7 +9,7 @@ This guide summarizes the day-to-day tasks most automations perform when integra
    .package(url: "https://github.com/stovak/SwiftHablare", from: "1.0.0")
    ```
 2. Add `SwiftHablare` to the target dependencies that need text-to-speech features.
-3. Ensure the host app targets macOS 14/iOS 17 or newer and uses Swift 6.0 or newer.
+3. Ensure the host app targets macOS 15/iOS 17 or newer and uses Swift 6.0 or newer with Xcode 16.4+.
 4. Link SwiftData in the host target (SwiftHablaré persists data through it).
 5. On iOS/macOS, entitle the app for microphone/speaker usage when playing audio.
 


### PR DESCRIPTION
## Summary
- update the GitHub Actions workflow to select Xcode 16.4 on macOS 15 like SwiftFountain
- raise the package and documentation macOS requirements to 15 and note the shared Xcode 16.4 toolchain

## Testing
- swift test *(fails on Linux because the Security framework is unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68e5b98832ac8321b5d5ef2aff3ca708